### PR TITLE
Check the buffer ticker channel in the main loop to avoid dropping data in Publish()

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -63,7 +63,6 @@ func (b *Buffer) Publish(event *Event) {
 	for _, sub := range b.subscribers {
 		select {
 		case sub.Send <- event:
-		case <-b.ticker.C:
 		}
 	}
 }
@@ -88,6 +87,7 @@ func (b *Buffer) Start() {
 		case <-b.term:
 			log.Println("Received on term chan")
 			break
+		case <-b.ticker.C:
 		}
 	}
 }


### PR DESCRIPTION
While working with the logslam code, I noticed a number of my events were not being published on occasion. It turns out if the ticker event is fired, `select` will fire one of the two events. It's possible the event gets dropped as a result.
